### PR TITLE
version not reliable, adding optional remote_file

### DIFF
--- a/cookbook/chef-server-blueprint/README.md
+++ b/cookbook/chef-server-blueprint/README.md
@@ -11,6 +11,35 @@ All the same ones chef-server supports
 #### Cookbooks
 - `chef-server` - Like I said, this is just a thin wrapper.
 
+#### Recipes
+<table>
+  <tr>
+    <th>name</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><tt>default</tt></td>
+    <td>Thin wrapper around chef-server::default which allows me to pass in attribute overrides through RightScale</td>
+  </tr>
+  <tr>
+    <td><tt>chef-ros-backup</tt></td>
+    <td>Backup chef server to Remote Object Storage(ex: AWS S3, RackSpace CloudFiles, etc)</td>
+  </tr>
+  <tr>
+    <td><tt>chef-ros-restore</tt></td>
+    <td>Restore chef server from a  Remote Object Storage(ex: AWS S3, RackSpace CloudFiles, etc) backup</td>
+  </tr>
+  <tr>
+    <td><tt>backup_schedule_enable</tt></td>
+    <td>Enables chef-server-blueprint::chef-ros-backup to be run hourly.</td>
+  </tr>
+  <tr>
+    <td><tt>backup_schedule_disable</tt></td>
+    <td>Disables chef-server-blueprint::chef-ros-backup from being run hourly.</td>
+  </tr>
+</table>
+
+
 Attributes
 ----------
 
@@ -36,6 +65,12 @@ It's in the metadata, which is the whole purpose of this cookbook, but...
     <td>Chef Server Version</td>
     <td><tt>:latest</tt></td>
   </tr>
+  <tr>
+    <td><tt>['chef-server-blueprint']['remote_file']</tt></td>
+    <td>String</td>
+    <td>Chef Server Binary URL</td>
+    <td><tt>none</tt></td>
+  </tr> 
 </table>
 
 Usage

--- a/cookbook/chef-server-blueprint/README.md
+++ b/cookbook/chef-server-blueprint/README.md
@@ -1,6 +1,6 @@
 chef-server-blueprint Cookbook
 ==============================
-This is just a very thin wrapper around chef-server::default which allows me to pass in attribute overrides through RightScale.  I.E. It specifies a couple attributes in the metadata.rb so that RightScale can parse it and present it to the user.
+This is a thin wrapper around chef-server::default which allows me to pass in attribute overrides through RightScale.  I.E. It specifies a couple attributes in the metadata.rb so that RightScale can parse it and present it to the user. Also contains chef-server backup and restore recipes.
 
 Requirements
 ------------

--- a/cookbook/chef-server-blueprint/README.md
+++ b/cookbook/chef-server-blueprint/README.md
@@ -11,7 +11,8 @@ All the same ones chef-server supports
 #### Cookbooks
 - `chef-server` - Like I said, this is just a thin wrapper.
 
-#### Recipes
+Recipes
+----------
 <table>
   <tr>
     <th>name</th>

--- a/cookbook/chef-server-blueprint/files/default/chef-backup.sh
+++ b/cookbook/chef-server-blueprint/files/default/chef-backup.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Author: Arem Chekunov
+# Author email: scorp.dev.null@gmail.com
+# repo: https://github.com/sc0rp1us/cehf-useful-scripts
+# env and func's
+_BACKUP_NAME="chef-backup_$(date +%Y-%m-%d)"
+_BACKUP_USER="root"
+_BACKUP_DIR="/var/backups"
+_SYS_TMP="/tmp"
+_TMP="${_SYS_TMP}/${_BACKUP_NAME}"
+_pg_dump(){
+su - opscode-pgsql -c "/opt/chef-server/embedded/bin/pg_dump -c opscode_chef"
+}
+syntax(){
+        echo ""
+        echo -e "\t$0 --backup                  # for backup"
+        echo -e "\t$0 --restore </from>.tar.bz2 # for restore"
+        echo ""
+}
+
+_chefBackup(){
+
+echo "Backup function"
+
+id ${_BACKUP_USER} &> /dev/null
+    _BACKUP_USER_EXIST=$?
+    if [[ ${_BACKUP_USER_EXIST} -ne 0 ]]; then
+        echo "You should have a backup user"
+    fi
+
+
+set -e
+set -x
+# Create folders
+mkdir -p ${_TMP}
+mkdir -p ${_TMP}/nginx
+mkdir -p ${_TMP}/cookbooks
+mkdir -p ${_TMP}/postgresql
+mkdir -p ${_BACKUP_DIR}/chef-backup
+
+# Backup files
+cp -a /var/opt/chef-server/nginx/{ca,etc} ${_TMP}/nginx
+cp -a /var/opt/chef-server/bookshelf/data/bookshelf/ ${_TMP}/cookbooks
+
+# Backup database
+_pg_dump > ${_TMP}/postgresql/pg_opscode_chef.sql
+
+cd ${_SYS_TMP}
+    if [[ -e ${_BACKUP_DIR}/chef-backup/chef-backup.tar.bz2 ]]; then
+        mv ${_BACKUP_DIR}/chef-backup/chef-backup.tar.bz2{,.previous}
+    fi
+    tar cjf ${_BACKUP_DIR}/chef-backup/chef-backup.tar.bz2 ${_BACKUP_NAME}
+    chown -R ${_BACKUP_USER}:${_BACKUP_USER} ${_BACKUP_DIR}/chef-backup/
+    chmod -R g-rwx,o-rwx ${_BACKUP_DIR}/chef-backup/
+
+
+    rm -Rf ${_TMP}
+}
+
+
+_chefRestore(){
+echo "Restore function"
+    _TMP_RESTORE=${_SYS_TMP}/restore ; mkdir -p ${_TMP_RESTORE}
+    if [[ ! -f ${source} ]]; then
+        echo "ERROR: file ${source} do not exist"
+        exit 1
+    fi
+
+    set -e
+    set -x
+
+    tar xjf ${source} -C ${_TMP_RESTORE}
+        mv /var/opt/chef-server/nginx/ca{,.$(date +%Y-%m-%d_%H:%M:%S).bak}
+        mv /var/opt/chef-server/nginx/etc{,.$(date +%Y-%m-%d_%H:%M:%S).bak}
+        if [[ -d /var/opt/chef-server/bookshelf/data/bookshelf ]]; then
+            mv /var/opt/chef-server/bookshelf/data/bookshelf{,.$(date +%Y-%m-%d_%H:%M:%S).bak}
+        fi
+        _pg_dump > /var/opt/chef-server/pg_opscode_chef.sql.$(date +%Y-%m-%d_%H:%M:%S).bak
+
+    cd ${_TMP_RESTORE}/*
+    _TMP_RESTORE_D=$(pwd)
+
+        chef-server-ctl reconfigure
+        su - opscode-pgsql -c "/opt/chef-server/embedded/bin/psql opscode_chef  < ${_TMP_RESTORE_D}/postgresql/pg_opscode_chef.sql"
+        chef-server-ctl stop
+
+        cp -a ${_TMP_RESTORE_D}/nginx/ca/              /var/opt/chef-server/nginx/
+        cp -a ${_TMP_RESTORE_D}/nginx/etc/             /var/opt/chef-server/nginx/
+        cp -a ${_TMP_RESTORE_D}/cookbooks/bookshelf/   /var/opt/chef-server/bookshelf/data/
+
+
+        chef-server-ctl start
+        sleep 30
+        chef-server-ctl reindex
+
+        cd ~
+        rm -Rf ${_TMP_RESTORE}
+}
+
+# tests
+if [[ ! -x /opt/chef-server/embedded/bin/pg_dump ]];then
+    echo "Use it script only on chef-server V11"
+    exit 1
+fi
+
+if [[ $(id -u) -ne 0 ]]; then
+    echo "You should to be root"
+    exit 1
+fi
+
+# body
+while [ "$#" -gt 0 ] ; do
+    case "$1" in
+        -h|--help)
+            syntax
+            exit 0
+            ;;
+        --backup)
+            action="backup"
+            shift 1
+            ;;
+        --restore)
+            action="restore"
+            source="${2}"
+            break
+            ;;
+        *)
+            syntax
+            exit 1
+            ;;
+
+    esac
+done
+
+
+if [[ ${action} == "backup" ]];then
+        _chefBackup
+elif [[ ${action} == "restore" ]];then
+        _chefRestore
+else
+        syntax
+        exit 1
+fi

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -21,13 +21,13 @@ recipe "chef-server-blueprint::backup_schedule_disable", "Disables chef-server-b
 
 attribute "chef-server-blueprint/api_fqdn",
     :display_name => "Chef Server FQDN",
-    :required => "required"
+    :required => "required",
     :recipes => [ "chef-server-blueprint::default" ]
 
 attribute "chef-server-blueprint/version",
     :display_name => "Chef Server Version",
     :required => "optional",
-    :default => "latest"
+    :default => "latest",
     :recipes => [ "chef-server-blueprint::default" ]
     
 attribute "chef-server-blueprint/remote_file",

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -22,16 +22,19 @@ recipe "chef-server-blueprint::backup_schedule_disable", "Disables chef-server-b
 attribute "chef-server-blueprint/api_fqdn",
     :display_name => "Chef Server FQDN",
     :required => "required"
+    :recipes => [ "chef-server-blueprint::default" ]
 
 attribute "chef-server-blueprint/version",
     :display_name => "Chef Server Version",
     :required => "optional",
     :default => "latest"
+    :recipes => [ "chef-server-blueprint::default" ]
     
 attribute "chef-server-blueprint/remote_file",
     :display_name => "Chef Server URL",
     :description =>  "Instead of specifying the Chef Server Version, you can provide a URL to a chef-server binary to be downloaded and installed. Ex: http://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chef-server-11.0.12-1.el6.x86_64.rpm",
-    :required => "optional"
+    :required => "optional",
+    :recipes => [ "chef-server-blueprint::default" ]
 
 
 # Backup attributes

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@ryangeyer.com'
 license          'All rights reserved'
 description      'Installs/Configures chef-server-blueprint'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'
 
 depends "chef-server"
 

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@ryangeyer.com'
 license          'All rights reserved'
 description      'Installs/Configures chef-server-blueprint'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.4'
+version          '0.1.5'
 
 depends "rightscale"
 depends "chef-server"

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@ryangeyer.com'
 license          'All rights reserved'
 description      'Installs/Configures chef-server-blueprint'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 
 depends "rightscale"
 depends "chef-server"

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@ryangeyer.com'
 license          'All rights reserved'
 description      'Installs/Configures chef-server-blueprint'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.3'
+version          '0.1.4'
 
 depends "rightscale"
 depends "chef-server"

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -6,6 +6,7 @@ description      'Installs/Configures chef-server-blueprint'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.2'
 
+depends "rightscale"
 depends "chef-server"
 
 # Support everything the chef-server cookbook supports

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@ryangeyer.com'
 license          'All rights reserved'
 description      'Installs/Configures chef-server-blueprint'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.2'
 
 depends "chef-server"
 
@@ -14,6 +14,10 @@ depends "chef-server"
 end
 
 recipe "chef-server-blueprint::default", "Same as chef-server::default, but with inputs and optional package download"
+recipe "chef-server-blueprint::chef-ros-backup", "Backup chef server to Remote Object Storage(ex: AWS S3, RackSpace CloudFiles, etc)"
+recipe "chef-server-blueprint::chef-ros-restore", "Restore chef server from a  Remote Object Storage(ex: AWS S3, RackSpace CloudFiles, etc) backup"
+recipe "chef-server-blueprint::backup_schedule_enable", "Enables chef-server-blueprint::chef-ros-backup to be run hourly."
+recipe "chef-server-blueprint::backup_schedule_disable", "Disables chef-server-blueprint::chef-ros-backup from being run hourly."
 
 attribute "chef-server-blueprint/api_fqdn",
     :display_name => "Chef Server FQDN",
@@ -28,3 +32,107 @@ attribute "chef-server-blueprint/remote_file",
     :display_name => "Chef Server URL",
     :description =>  "Instead of specifying the Chef Server Version, you can provide a URL to a chef-server binary to be downloaded and installed. Ex: http://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chef-server-11.0.12-1.el6.x86_64.rpm",
     :required => "optional"
+
+
+# Backup attributes
+attribute "chef-server-blueprint/backup/lineage",
+  :display_name => "Chef Server Backup Lineage",
+  :description =>
+    "The prefix that will be used to name/locate the backup of a particular" +
+    " VPN server. Example: text: companyx_certs",
+  :required => "optional",
+  :recipes => [
+    "chef-server-blueprint::chef-ros-backup",
+    "chef-server-blueprint::chef-ros-restore",
+	"chef-server-blueprint::backup_schedule_enable"
+  ]
+
+attribute "chef-server-blueprint/backup",
+  :display_name => "Import/export settings for database dump file management.",
+  :type => "hash"
+
+attribute "chef-server-blueprint/backup/storage_account_provider",
+  :display_name => "Dump Storage Account Provider",
+  :description =>
+    "Location where the dump file will be saved." +
+    " Used by dump recipes to back up to remote object storage" +
+    " (complete list of supported storage locations is in input dropdown)." +
+    " Example: s3",
+  :required => "optional",
+  :choice => [
+    "s3",
+    "Cloud_Files",
+    "Cloud_Files_UK",
+    "google",
+    "azure",
+    "swift",
+    "SoftLayer_Dallas",
+    "SoftLayer_Singapore",
+    "SoftLayer_Amsterdam"
+  ],
+  :recipes => [
+    "chef-server-blueprint::chef-ros-backup",
+    "chef-server-blueprint::chef-ros-restore",
+	"chef-server-blueprint::backup_schedule_enable"
+  ]
+
+attribute "chef-server-blueprint/backup/storage_account_id",
+  :display_name => "Chef Server Backup Storage Account ID",
+  :description =>
+    "In order to write the Chef Server backup file to the specified cloud storage location," +
+    " you need to provide cloud authentication credentials." +
+    " For Amazon S3, use your Amazon access key ID" +
+    " (e.g., cred:AWS_ACCESS_KEY_ID). For Rackspace Cloud Files, use your" +
+    " Rackspace login username (e.g., cred:RACKSPACE_USERNAME)." +
+    " For OpenStack Swift the format is: 'tenantID:username'." +
+    " Example: cred:AWS_ACCESS_KEY_ID",
+  :required => "optional",
+  :recipes => [
+    "chef-server-blueprint::chef-ros-backup",
+    "chef-server-blueprint::chef-ros-restore",
+	"chef-server-blueprint::backup_schedule_enable"
+  ]
+
+attribute "chef-server-blueprint/backup/storage_account_secret",
+  :display_name => "Chef Server Backup Storage Account Secret",
+  :description =>
+    "In order to write the Chef Server backup file to the specified cloud storage location," +
+    " you need to provide cloud authentication credentials." +
+    " For Amazon S3, use your AWS secret access key" +
+    " (e.g., cred:AWS_SECRET_ACCESS_KEY)." +
+    " For Rackspace Cloud Files, use your Rackspace account API key" +
+    " (e.g., cred:RACKSPACE_AUTH_KEY). Example: cred:AWS_SECRET_ACCESS_KEY",
+  :required => "optional",
+  :recipes => [
+    "chef-server-blueprint::chef-ros-backup",
+    "chef-server-blueprint::chef-ros-restore",
+	"chef-server-blueprint::backup_schedule_enable"
+  ]
+
+attribute "chef-server-blueprint/backup/storage_account_endpoint",
+  :display_name => "Chef Server Backup Storage Endpoint URL",
+  :description =>
+    "The endpoint URL for the storage cloud. This is used to override the" +
+    " default endpoint or for generic storage clouds such as Swift." +
+    " Example: http://endpoint_ip:5000/v2.0/tokens",
+  :required => "optional",
+  :default => "",
+  :recipes => [
+    "chef-server-blueprint::chef-ros-backup",
+    "chef-server-blueprint::chef-ros-restore",
+	"chef-server-blueprint::backup_schedule_enable"
+  ]
+
+attribute "chef-server-blueprint/backup/container",
+  :display_name => "Chef Server Backup Container",
+  :description =>
+    "The cloud storage location where the dump file will be saved to" +
+    " or restored from. For Amazon S3, use the bucket name." +
+    " For Rackspace Cloud Files, use the container name." +
+    " Example: db_dump_bucket",
+  :required => "optional",
+  :recipes => [
+    "chef-server-blueprint::chef-ros-backup",
+    "chef-server-blueprint::chef-ros-restore",
+	"chef-server-blueprint::backup_schedule_enable"
+  ]

--- a/cookbook/chef-server-blueprint/metadata.rb
+++ b/cookbook/chef-server-blueprint/metadata.rb
@@ -13,13 +13,18 @@ depends "chef-server"
   supports os
 end
 
-recipe "chef-server-blueprint::default", "Same as chef-server::default, but with inputs"
+recipe "chef-server-blueprint::default", "Same as chef-server::default, but with inputs and optional package download"
 
 attribute "chef-server-blueprint/api_fqdn",
     :display_name => "Chef Server FQDN",
     :required => "required"
 
 attribute "chef-server-blueprint/version",
-          :display_name => "Chef Server Version",
-          :required => "optional",
-          :default => "latest"
+    :display_name => "Chef Server Version",
+    :required => "optional",
+    :default => "latest"
+    
+attribute "chef-server-blueprint/remote_file",
+    :display_name => "Chef Server URL",
+    :description =>  "Instead of specifying the Chef Server Version, you can provide a URL to a chef-server binary to be downloaded and installed. Ex: http://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chef-server-11.0.12-1.el6.x86_64.rpm",
+    :required => "optional"

--- a/cookbook/chef-server-blueprint/recipes/backup_schedule_disable.rb
+++ b/cookbook/chef-server-blueprint/recipes/backup_schedule_disable.rb
@@ -5,6 +5,7 @@
 rightscale_marker :begin
 
 file "/etc/cron.hourly/chef_server_backup" do
+  backup false
   action :delete
 end
 

--- a/cookbook/chef-server-blueprint/recipes/backup_schedule_disable.rb
+++ b/cookbook/chef-server-blueprint/recipes/backup_schedule_disable.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook Name:: chef-server-blueprint
+#
+
+rightscale_marker :begin
+
+file "/etc/cron.hourly/chef_server_backup" do
+  action :delete
+end
+
+rightscale_marker :end

--- a/cookbook/chef-server-blueprint/recipes/backup_schedule_enable.rb
+++ b/cookbook/chef-server-blueprint/recipes/backup_schedule_enable.rb
@@ -7,7 +7,7 @@ rightscale_marker :begin
 file "/etc/cron.hourly/chef_server_backup" do
   content %Q(
 #!/bin/sh
-rs_run_recipe --name 'chef-server-blueprint::chef-ros-backup' 2>&1 >> /var/log/rs_backup.log
+rs_run_recipe --policy 'chef-server-blueprint::chef-ros-backup' --name 'chef-server-blueprint::chef-ros-backup' 2>&1 >> /var/log/rs_backup.log
 exit 0
   )
   mode 00700

--- a/cookbook/chef-server-blueprint/recipes/backup_schedule_enable.rb
+++ b/cookbook/chef-server-blueprint/recipes/backup_schedule_enable.rb
@@ -7,7 +7,7 @@ rightscale_marker :begin
 file "/etc/cron.hourly/chef_server_backup" do
   content %Q(
 #!/bin/sh
-rs_run_recipe --name ' chef-server-blueprint::chef-ros-backup' 2>&1 >> /var/log/rs_backup.log
+rs_run_recipe --name 'chef-server-blueprint::chef-ros-backup' 2>&1 >> /var/log/rs_backup.log
 exit 0
   )
   mode 00700

--- a/cookbook/chef-server-blueprint/recipes/backup_schedule_enable.rb
+++ b/cookbook/chef-server-blueprint/recipes/backup_schedule_enable.rb
@@ -1,0 +1,16 @@
+#
+# Cookbook Name:: chef-server-blueprint
+#
+
+rightscale_marker :begin
+
+file "/etc/cron.hourly/chef_server_backup" do
+  content %Q(
+#!/bin/sh
+rs_run_recipe --name ' chef-server-blueprint::chef-ros-backup' 2>&1 >> /var/log/rs_backup.log
+exit 0
+  )
+  mode 00700
+end
+
+rightscale_marker :end

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
@@ -40,7 +40,7 @@ environment_variables = {
 }.merge(options)
 
 backup_src = "/var/backups/chef-backup/chef-backup.tar.bz2"
-backup_dst = node['chef-server-blueprint']['backup']['lineage'] + "-" + Time.now.strftime("%Y%m%d%H%M") + ".tar.gz"
+backup_dst = node['chef-server-blueprint']['backup']['lineage'] + "-" + Time.now.strftime("%Y%m%d%H%M") + ".tar.bz2"
 
 bash "*** Uploading '#{backup_src}' to '#{cloud}' container '#{container}/chef-backups/#{backup_dst}'" do
   flags "-ex"

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
@@ -1,0 +1,55 @@
+#
+# Cookbook Name:: chef-server-blueprint
+#
+# Backup chef server to Remote Object Storage(ex: AWS S3, RackSpace CloudFiles, etc)
+
+rightscale_marker :begin
+
+log "*** in recipe: chef-server-blueprint::chef-ros-backup"
+
+raise "*** ROS gem missing, please add rightscale::install_tools recipes to runlist." unless File.exists?("/opt/rightscale/sandbox/bin/ros_util")
+
+if (("#{node[:chef-server-blueprint][:backup][:storage_account_id]}" == "") ||
+    ("#{node[:chef-server-blueprint][:backup][:storage_account_secret]}" == "") ||
+    ("#{node[:chef-server-blueprint][:backup][:container]}" == "") ||
+    ("#{node[:chef-server-blueprint][:backup][:lineage]}" == ""))
+  raise "*** Attributes chef-server-blueprint/backup/storage_account_id, storage_account_secret, container and lineage are required by chef-server-blueprint::chef-ros-backup. Aborting"
+end
+
+container = node[:chef-server-blueprint][:backup][:container]
+cloud = node[:chef-server-blueprint][:backup][:storage_account_provider]
+
+# Overrides default endpoint or for generic storage clouds such as Swift.
+# Is set as ENV['STORAGE_OPTIONS'] for ros_util.
+require 'json'
+
+options =
+  if node[:chef-server-blueprint][:backup][:storage_account_endpoint].to_s.empty?
+    {}
+  else
+    {'STORAGE_OPTIONS' => JSON.dump({
+      :endpoint => node[:chef-server-blueprint][:backup][:storage_account_endpoint],
+      :cloud => node[:chef-server-blueprint][:backup][:storage_account_provider].to_sym
+    })}
+  end
+
+environment_variables = {
+  'STORAGE_ACCOUNT_ID' => node[:chef-server-blueprint][:backup][:storage_account_id],
+  'STORAGE_ACCOUNT_SECRET' => node[:chef-server-blueprint][:backup][:storage_account_secret]
+}.merge(options)
+
+backup_script = ::File.join(::File.dirname(__FILE__), "..", "files", "default", "chef-backup.sh")
+backup_src = "/var/backups/chef-backup/chef-backup.tar.bz2"
+backup_dst = node[:chef-server-blueprint][:backup][:lineage] + "-" + Time.now.strftime("%Y%m%d%H%M") + ".tar.gz"
+
+bash "*** Uploading '#{backup_src}' to '#{cloud}' container '#{container}/chef-backups/#{backup_dst}'" do
+  flags "-ex"
+  user "root"
+  environment environment_variables
+  code <<-EOH
+    #{backup_script}
+    /opt/rightscale/sandbox/bin/ros_util put --container #{container} --cloud #{cloud} --source #{backup_src} --dest "chef-backups/#{backup_dst}"
+  EOH
+end
+
+rightscale_marker :end

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
@@ -9,38 +9,38 @@ log "*** in recipe: chef-server-blueprint::chef-ros-backup"
 
 raise "*** ROS gem missing, please add rightscale::install_tools recipes to runlist." unless File.exists?("/opt/rightscale/sandbox/bin/ros_util")
 
-if (("#{node[:chef-server-blueprint][:backup][:storage_account_id]}" == "") ||
-    ("#{node[:chef-server-blueprint][:backup][:storage_account_secret]}" == "") ||
-    ("#{node[:chef-server-blueprint][:backup][:container]}" == "") ||
-    ("#{node[:chef-server-blueprint][:backup][:lineage]}" == ""))
+if (("#{node['chef-server-blueprint']['backup']['storage_account_id']}" == "") ||
+    ("#{node['chef-server-blueprint']['backup']['storage_account_secret']}" == "") ||
+    ("#{node['chef-server-blueprint']['backup']['container']}" == "") ||
+    ("#{node['chef-server-blueprint']['backup']['lineage']}" == ""))
   raise "*** Attributes chef-server-blueprint/backup/storage_account_id, storage_account_secret, container and lineage are required by chef-server-blueprint::chef-ros-backup. Aborting"
 end
 
-container = node[:chef-server-blueprint][:backup][:container]
-cloud = node[:chef-server-blueprint][:backup][:storage_account_provider]
+container = node['chef-server-blueprint']['backup']['container']
+cloud = node['chef-server-blueprint']['backup']['storage_account_provider']
+backup_script = ::File.join(::File.dirname(__FILE__), "..", "files", "default", "chef-backup.sh")
 
 # Overrides default endpoint or for generic storage clouds such as Swift.
 # Is set as ENV['STORAGE_OPTIONS'] for ros_util.
 require 'json'
 
 options =
-  if node[:chef-server-blueprint][:backup][:storage_account_endpoint].to_s.empty?
+  if node['chef-server-blueprint']['backup']['storage_account_endpoint'].to_s.empty?
     {}
   else
     {'STORAGE_OPTIONS' => JSON.dump({
-      :endpoint => node[:chef-server-blueprint][:backup][:storage_account_endpoint],
-      :cloud => node[:chef-server-blueprint][:backup][:storage_account_provider].to_sym
+      :endpoint => node['chef-server-blueprint']['backup']['storage_account_endpoint'],
+      :cloud => node['chef-server-blueprint']['backup']['storage_account_provider'].to_sym
     })}
   end
 
 environment_variables = {
-  'STORAGE_ACCOUNT_ID' => node[:chef-server-blueprint][:backup][:storage_account_id],
-  'STORAGE_ACCOUNT_SECRET' => node[:chef-server-blueprint][:backup][:storage_account_secret]
+  'STORAGE_ACCOUNT_ID' => node['chef-server-blueprint']['backup']['storage_account_id'],
+  'STORAGE_ACCOUNT_SECRET' => node['chef-server-blueprint']['backup']['storage_account_secret']
 }.merge(options)
 
-backup_script = ::File.join(::File.dirname(__FILE__), "..", "files", "default", "chef-backup.sh")
 backup_src = "/var/backups/chef-backup/chef-backup.tar.bz2"
-backup_dst = node[:chef-server-blueprint][:backup][:lineage] + "-" + Time.now.strftime("%Y%m%d%H%M") + ".tar.gz"
+backup_dst = node['chef-server-blueprint']['backup']['lineage'] + "-" + Time.now.strftime("%Y%m%d%H%M") + ".tar.gz"
 
 bash "*** Uploading '#{backup_src}' to '#{cloud}' container '#{container}/chef-backups/#{backup_dst}'" do
   flags "-ex"

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
@@ -47,7 +47,7 @@ bash "*** Uploading '#{backup_src}' to '#{cloud}' container '#{container}/chef-b
   user "root"
   environment environment_variables
   code <<-EOH
-    #{backup_script}
+    #{backup_script} --backup
     /opt/rightscale/sandbox/bin/ros_util put --container #{container} --cloud #{cloud} --source #{backup_src} --dest "chef-backups/#{backup_dst}"
   EOH
 end

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-backup.rb
@@ -47,6 +47,7 @@ bash "*** Uploading '#{backup_src}' to '#{cloud}' container '#{container}/chef-b
   user "root"
   environment environment_variables
   code <<-EOH
+    chmod +x #{backup_script}
     #{backup_script} --backup
     /opt/rightscale/sandbox/bin/ros_util put --container #{container} --cloud #{cloud} --source #{backup_src} --dest "chef-backups/#{backup_dst}"
   EOH

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
@@ -49,7 +49,7 @@ bash "*** Downloading latest backup from '#{container}/chef-backups/', cloud #{c
     /opt/rightscale/sandbox/bin/ros_util get --cloud #{cloud}\
                                              --container #{container}\
                                              --dest $tmp_dir/chef-backup.tar.bz2\
-                                             --source #{prefix} --latest
+                                             --source chef-backups/#{prefix} --latest
     chmod +x #{backup_script}
     #{backup_script} --restore $tmp_dir/chef-backup.tar.bz2
   EOH

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
@@ -48,10 +48,11 @@ bash "*** Downloading latest backup from '#{container}/chef-backups/', cloud #{c
     tmp_dir=`mktemp -d`
     /opt/rightscale/sandbox/bin/ros_util get --cloud #{cloud}\
                                              --container #{container}\
-                                             --dest $tmp_dir/\
+                                             --dest $tmp_dir/chef-backup.tar.bz2\
                                              --source #{prefix} --latest
-    #{backup_script} --restore $tmp_dir/*
+    #{backup_script} --restore $tmp_dir/chef-backup.tar.bz2
   EOH
 end
 
 rightscale_marker :end
+

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
@@ -50,6 +50,7 @@ bash "*** Downloading latest backup from '#{container}/chef-backups/', cloud #{c
                                              --container #{container}\
                                              --dest $tmp_dir/chef-backup.tar.bz2\
                                              --source #{prefix} --latest
+    chmod +x #{backup_script}
     #{backup_script} --restore $tmp_dir/chef-backup.tar.bz2
   EOH
 end

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
@@ -9,16 +9,16 @@ log "*** in recipe: chef-server-blueprint::chef-ros-restore"
 
 raise "*** ROS gem missing, please add rightscale::install_tools recipes to runlist." unless File.exists?("/opt/rightscale/sandbox/bin/ros_util")
 
-if (("#{node[:chef-server-blueprint][:backup][:storage_account_id]}" == "") ||
-    ("#{node[:chef-server-blueprint][:backup][:storage_account_secret]}" == "") ||
-    ("#{node[:chef-server-blueprint][:backup][:container]}" == "") ||
-    ("#{node[:chef-server-blueprint][:backup][:lineage]}" == ""))
+if (("#{node['chef-server-blueprint']['backup']['storage_account_id']}" == "") ||
+    ("#{node['chef-server-blueprint']['backup']['storage_account_secret']}" == "") ||
+    ("#{node['chef-server-blueprint']['backup']['container']}" == "") ||
+    ("#{node['chef-server-blueprint']['backup']['lineage']}" == ""))
   raise "*** Attributes chef-server-blueprint/backup/storage_account_id, storage_account_secret, container and lineage are required by chef-server-blueprint::chef-ros-backup. Aborting"
 end
 
-container = node[:chef-server-blueprint][:backup][:container]
-cloud = node[:chef-server-blueprint][:backup][:storage_account_provider]
-prefix = node[:chef-server-blueprint][:backup][:lineage]
+container = node['chef-server-blueprint']['backup']['container']
+cloud = node['chef-server-blueprint']['backup']['storage_account_provider']
+prefix = node['chef-server-blueprint']['backup']['lineage']
 backup_script = ::File.join(::File.dirname(__FILE__), "..", "files", "default", "chef-backup.sh")
 
 # Overrides default endpoint or for generic storage clouds such as Swift.
@@ -26,18 +26,18 @@ backup_script = ::File.join(::File.dirname(__FILE__), "..", "files", "default", 
 require 'json'
 
 options =
-  if node[:chef-server-blueprint][:backup][:storage_account_endpoint].to_s.empty?
+  if node['chef-server-blueprint']['backup']['storage_account_endpoint'].to_s.empty?
     {}
   else
     {'STORAGE_OPTIONS' => JSON.dump({
-      :endpoint => node[:chef-server-blueprint][:backup][:storage_account_endpoint],
-      :cloud => node[:chef-server-blueprint][:backup][:storage_account_provider].to_sym
+      :endpoint => node['chef-server-blueprint']['backup']['storage_account_endpoint'],
+      :cloud => node['chef-server-blueprint']['backup']['storage_account_provider'].to_sym
     })}
   end
 
 environment_variables = {
-  'STORAGE_ACCOUNT_ID' => node[:chef-server-blueprint][:backup][:storage_account_id],
-  'STORAGE_ACCOUNT_SECRET' => node[:chef-server-blueprint][:backup][:storage_account_secret]
+  'STORAGE_ACCOUNT_ID' => node['chef-server-blueprint']['backup']['storage_account_id'],
+  'STORAGE_ACCOUNT_SECRET' => node['chef-server-blueprint']['backup']['storage_account_secret']
 }.merge(options)
 
 bash "*** Downloading latest backup from '#{container}/chef-backups/', cloud #{cloud}" do
@@ -48,7 +48,7 @@ bash "*** Downloading latest backup from '#{container}/chef-backups/', cloud #{c
     tmp_dir=`mktemp -d`
     /opt/rightscale/sandbox/bin/ros_util get --cloud #{cloud}\
                                              --container #{container}\
-                                             --dest $tmp_dir\
+                                             --dest $tmp_dir/\
                                              --source #{prefix} --latest
     #{backup_script} --restore $tmp_dir/*
   EOH

--- a/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
+++ b/cookbook/chef-server-blueprint/recipes/chef-ros-restore.rb
@@ -1,0 +1,43 @@
+#
+# Cookbook Name:: chef-server-blueprint
+#
+# Restore chef server from Remote Object Storage(ex: AWS S3, RackSpace CloudFiles, etc)
+
+rightscale_marker :begin
+
+log "*** in recipe: chef-server-blueprint::chef-ros-restore"
+
+raise "*** ROS gem missing, please add rightscale::install_tools recipes to runlist." unless File.exists?("/opt/rightscale/sandbox/bin/ros_util")
+
+if (("#{node[:chef-server-blueprint][:backup][:storage_account_id]}" == "") ||
+    ("#{node[:chef-server-blueprint][:backup][:storage_account_secret]}" == "") ||
+    ("#{node[:chef-server-blueprint][:backup][:container]}" == "") ||
+    ("#{node[:chef-server-blueprint][:backup][:lineage]}" == ""))
+  raise "*** Attributes chef-server-blueprint/backup/storage_account_id, storage_account_secret, container and lineage are required by chef-server-blueprint::chef-ros-backup. Aborting"
+end
+
+container = node[:chef-server-blueprint][:backup][:container]
+cloud = node[:chef-server-blueprint][:backup][:storage_account_provider]
+
+# Overrides default endpoint or for generic storage clouds such as Swift.
+# Is set as ENV['STORAGE_OPTIONS'] for ros_util.
+require 'json'
+
+options =
+  if node[:chef-server-blueprint][:backup][:storage_account_endpoint].to_s.empty?
+    {}
+  else
+    {'STORAGE_OPTIONS' => JSON.dump({
+      :endpoint => node[:chef-server-blueprint][:backup][:storage_account_endpoint],
+      :cloud => node[:chef-server-blueprint][:backup][:storage_account_provider].to_sym
+    })}
+  end
+
+environment_variables = {
+  'STORAGE_ACCOUNT_ID' => node[:chef-server-blueprint][:backup][:storage_account_id],
+  'STORAGE_ACCOUNT_SECRET' => node[:chef-server-blueprint][:backup][:storage_account_secret]
+}.merge(options)
+
+backup_script = ::File.join(::File.dirname(__FILE__), "..", "files", "default", "chef-backup.sh")
+
+rightscale_marker :end

--- a/cookbook/chef-server-blueprint/recipes/default.rb
+++ b/cookbook/chef-server-blueprint/recipes/default.rb
@@ -12,20 +12,20 @@ rightscale_marker :begin
 node["chef-server"]["api_fqdn"] = node["chef-server-blueprint"]["api_fqdn"]
 node["chef-server"]["version"] = node["chef-server-blueprint"]["version"]
 
-if node['chef-server']['remote_file'].nil? || node['chef-server']['remote_file'].empty?
-  log "*** Input node['chef-server']['remote_file'] is undefined, not setting node['chef-server']['package_file']"
+if node['chef-server-blueprint']['remote_file'].nil? || node['chef-server-blueprint']['remote_file'].empty?
+  log "*** Input node['chef-server-blueprint']['remote_file'] is undefined, not setting node['chef-server']['package_file']"
 else
   filename=""
-  if (node['chef-server']['remote_file'] =~ /.+\/(.+)$/)
+  if (node['chef-server-blueprint']['remote_file'] =~ /.+\/(.+)$/)
     filename=$1
   else
-    throw "*** node['chef-server']['remote_file'] is not a valid URL, aborting..."
+    throw "*** node['chef-server-blueprint']['remote_file'] with value #{node['chef-server-blueprint']['remote_file']} is not a valid URL, aborting..."
   end
   
-  log "*** Downloading #{node['chef-server']['remote_file']} to /root/#{filename}"
+  log "*** Downloading #{node['chef-server-blueprint']['remote_file']} to /root/#{filename}"
 
   remote_file "/root/#{filename}" do
-    source "#{node['chef-server']['remote_file']}"
+    source "#{node['chef-server-blueprint']['remote_file']}"
     action :create_if_missing
   end
   

--- a/cookbook/chef-server-blueprint/recipes/default.rb
+++ b/cookbook/chef-server-blueprint/recipes/default.rb
@@ -29,7 +29,7 @@ else
     action :create_if_missing
   end
   
-  log "*** Setting #{node['chef-server']['package_file']} to /root/#{filename}"
+  log "*** Setting node['chef-server']['package_file'] to /root/#{filename}"
   node['chef-server']['package_file']="/root/#{filename}"
 end
   

--- a/cookbook/chef-server-blueprint/recipes/default.rb
+++ b/cookbook/chef-server-blueprint/recipes/default.rb
@@ -7,7 +7,33 @@
 # All rights reserved - Do Not Redistribute
 #
 
+rightscale_marker :begin
+
 node["chef-server"]["api_fqdn"] = node["chef-server-blueprint"]["api_fqdn"]
 node["chef-server"]["version"] = node["chef-server-blueprint"]["version"]
 
+if node['chef-server']['remote_file'].nil? || node['chef-server']['remote_file'].empty?
+  log "*** Input node['chef-server']['remote_file'] is undefined, not setting node['chef-server']['package_file']"
+else
+  filename=""
+  if (node['chef-server']['remote_file'] =~ /.+\/(.+)$/)
+    filename=$1
+  else
+    throw "*** node['chef-server']['remote_file'] is not a valid URL, aborting..."
+  end
+  
+  log "*** Downloading #{node['chef-server']['remote_file']} to /root/#{filename}"
+
+  remote_file "/root/#{filename}" do
+    source "#{node['chef-server']['remote_file']}"
+    action :create_if_missing
+  end
+  
+  log "*** Setting #{node['chef-server']['package_file']} to /root/#{filename}"
+  node['chef-server']['package_file']="/root/#{filename}"
+end
+  
+log "*** Including recipe chef-server::default"
 include_recipe "chef-server::default"
+
+rightscale_marker :end


### PR DESCRIPTION
Hey Ryan,

Chef server that launched fine using attribute 'chef-server-blueprint/version=11.10' is now failing with:

```
10:28:57: Omnitruck download-server request: http://www.opscode.com/chef/download-server?p=el&pv=6&m=x86_64&v=11.10&prerelease=false&nightlies=false
*ERROR> Execution failed
*ERROR> Execution error:
Could not locate chef-server package matching version '11.10' for node.

The error occurred line 29 of [COOKBOOKS]//default/3f22227d144b8f9d70ad41f95fb535ee/chef-server/recipes/default.rb in method 'from_file' while executing:

27     err_msg << " nightly" if node['chef-server']['nightlies']
28     err_msg << " package matching version '#{node['chef-server']['version']}' for node."
**     raise err_msg
30   end
31 else

*ERROR> Subprocess exited with 1
```

To make this more reliable, I added attribute 'chef-server-blueprint/remote_file' that can take an HTTP(S) URL(Ex: http://opscode-omnibus-packages.s3.amazonaws.com/el/6/x86_64/chef-server-11.0.12-1.el6.x86_64.rpm) of the chef binary to install. Also, considering the size(~200MB) some might want to drop this in a storage  close to the servers.
